### PR TITLE
Fix: query for algo's compatible datasets

### DIFF
--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -179,7 +179,8 @@ export default function Compute({
       // verify if the algorithms in the trusted list share the same endpoint of the dataset
       const sameProviderEndpointAlgorithms = queryResults.results.filter(
         (algo) =>
-          algo.service[1].serviceEndpoint === computeService.serviceEndpoint
+          algo.findServiceByType('compute')?.serviceEndpoint ===
+          computeService.serviceEndpoint
       )
       setDdoAlgorithmList(sameProviderEndpointAlgorithms)
 

--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -169,21 +169,30 @@ export default function Compute({
     ) {
       algorithmSelectionList = []
     } else {
-      const gueryResults = await queryMetadata(
+      const queryResults = await queryMetadata(
         getQuerryString(
           computeService.attributes.main.privacy.publisherTrustedAlgorithms,
           ddo.chainId
         ),
         source.token
       )
-      setDdoAlgorithmList(gueryResults.results)
-      const datasetComputeService = ddo.findServiceByType('compute')
-      algorithmSelectionList = await transformDDOToAssetSelection(
-        undefined,
-        gueryResults.results,
-        [],
-        newCancelToken()
+      // verify if the algorithms in the trusted list share the same endpoint of the dataset
+      const sameProviderEndpointAlgorithms = queryResults.results.filter(
+        (algo) =>
+          algo.service[1].serviceEndpoint === computeService.serviceEndpoint
       )
+      setDdoAlgorithmList(sameProviderEndpointAlgorithms)
+
+      if (sameProviderEndpointAlgorithms.length === 0) {
+        algorithmSelectionList = []
+      } else {
+        algorithmSelectionList = await transformDDOToAssetSelection(
+          undefined,
+          sameProviderEndpointAlgorithms,
+          [],
+          newCancelToken()
+        )
+      }
     }
     return algorithmSelectionList
   }

--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -311,7 +311,6 @@ export default function Compute({
       }
 
       if (!hasPreviousDatasetOrder && !hasDatatoken) {
-        console.log(price, ddo)
         const tx = await buyDT('1', price, ddo)
         if (!tx) {
           setError('Error buying datatoken. Please try again.')
@@ -321,7 +320,6 @@ export default function Compute({
       }
 
       if (!hasPreviousAlgorithmOrder && !hasAlgoAssetDatatoken) {
-        console.log(algorithmPrice, selectedAlgorithmAsset)
         const tx = await buyDT('1', algorithmPrice, selectedAlgorithmAsset)
         if (!tx) {
           setError('Error buying datatoken. Please try again.')

--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -179,8 +179,10 @@ export default function Compute({
       // verify if the algorithms in the trusted list share the same endpoint of the dataset
       const sameProviderEndpointAlgorithms = queryResults.results.filter(
         (algo) =>
-          algo.findServiceByType('access')?.serviceEndpoint ===
-          computeService.serviceEndpoint
+          (
+            algo.findServiceByType('compute') ||
+            algo.findServiceByType('access')
+          )?.serviceEndpoint === computeService.serviceEndpoint
       )
       setDdoAlgorithmList(sameProviderEndpointAlgorithms)
 

--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -159,7 +159,6 @@ export default function Compute({
   async function getAlgorithmList(): Promise<AssetSelectionAsset[]> {
     const source = axios.CancelToken.source()
     const computeService = ddo.findServiceByType('compute')
-
     if (
       !computeService.attributes.main.privacy ||
       !computeService.attributes.main.privacy.publisherTrustedAlgorithms ||
@@ -169,33 +168,22 @@ export default function Compute({
     )
       return []
 
-    const queryResults = await queryMetadata(
+    const gueryResults = await queryMetadata(
       getQuerryString(
         computeService.attributes.main.privacy.publisherTrustedAlgorithms,
         ddo.chainId
       ),
       source.token
     )
-    // verify if the algorithms in the trusted list share the same endpoint of the dataset
-    const sameProviderEndpointAlgorithms = queryResults.results.filter(
-      (algo) => {
-        const algoService = algo.findServiceByType('compute')
-          ? algo.findServiceByType('compute')
-          : algo.findServiceByType('access')
-
-        return algoService?.serviceEndpoint === computeService.serviceEndpoint
-      }
-    )
-    setDdoAlgorithmList(sameProviderEndpointAlgorithms)
-
-    if (sameProviderEndpointAlgorithms.length === 0) return []
-
+    setDdoAlgorithmList(gueryResults.results)
+    const datasetComputeService = ddo.findServiceByType('compute')
     const algorithmSelectionList = await transformDDOToAssetSelection(
       undefined,
-      sameProviderEndpointAlgorithms,
+      gueryResults.results,
       [],
       newCancelToken()
     )
+
     return algorithmSelectionList
   }
 

--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -179,7 +179,7 @@ export default function Compute({
       // verify if the algorithms in the trusted list share the same endpoint of the dataset
       const sameProviderEndpointAlgorithms = queryResults.results.filter(
         (algo) =>
-          algo.findServiceByType('compute')?.serviceEndpoint ===
+          algo.findServiceByType('access')?.serviceEndpoint ===
           computeService.serviceEndpoint
       )
       setDdoAlgorithmList(sameProviderEndpointAlgorithms)

--- a/src/components/organisms/AssetContent/AlgorithmDatasetsListForCompute.tsx
+++ b/src/components/organisms/AssetContent/AlgorithmDatasetsListForCompute.tsx
@@ -26,7 +26,7 @@ export default function AlgorithmDatasetsListForCompute({
       )
       const datasets = await getAlgorithmDatasetsForCompute(
         algorithmDid,
-        datasetComputeService?.serviceEndpoint,
+        undefined,
         dataset?.chainId,
         newCancelToken()
       )

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -58,11 +58,7 @@ export default function SearchPage({
     async (parsed: queryString.ParsedQuery<string>, chainIds: number[]) => {
       setLoading(true)
       setTotalResults(undefined)
-      console.log(chainIds)
       const queryResult = await getResults(parsed, chainIds, newCancelToken())
-      getResults(parsed, chainIds, newCancelToken()).then((data) =>
-        console.log(data)
-      )
       setQueryResult(queryResult)
       setTotalResults(queryResult.totalResults)
       setTotalPagesNumber(queryResult.totalPages)

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -58,7 +58,11 @@ export default function SearchPage({
     async (parsed: queryString.ParsedQuery<string>, chainIds: number[]) => {
       setLoading(true)
       setTotalResults(undefined)
+      console.log(chainIds)
       const queryResult = await getResults(parsed, chainIds, newCancelToken())
+      getResults(parsed, chainIds, newCancelToken()).then((data) =>
+        console.log(data)
+      )
       setQueryResult(queryResult)
       setTotalResults(queryResult.totalResults)
       setTotalPagesNumber(queryResult.totalPages)

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -32,10 +32,13 @@ export const MAXIMUM_NUMBER_OF_PAGES_WITH_RESULTS = 476
  * @param value the value of the filter
  * @returns json structure of the es filter
  */
+type TFilterValue = string | number | boolean | number[] | string[]
+type TFilterKey = 'terms' | 'term' | 'match' | 'match_phrase'
+
 export function getFilterTerm(
   filterField: string,
-  value: string | number | boolean | number[] | string[],
-  key: 'terms' | 'term' | 'match' | 'match_phrase' = 'term'
+  value: TFilterValue,
+  key: TFilterKey = 'term'
 ): FilterTerm {
   const isArray = Array.isArray(value)
   const useKey = key === 'term' ? (isArray ? 'terms' : 'term') : key

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -331,12 +331,11 @@ export async function getAlgorithmDatasetsForCompute(
   const baseQueryParams = {
     chainIds: [datasetChainId],
     filters: [
-      {
-        match: {
-          'service.attributes.main.privacy.publisherTrustedAlgorithms.did':
-            algorithmId
-        }
-      }
+      getFilterTerm(
+        'service.attributes.main.privacy.publisherTrustedAlgorithms.did',
+        algorithmId,
+        'match'
+      )
     ],
     sortOptions: {
       sortBy: SortTermOptions.Created,

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -35,7 +35,7 @@ export const MAXIMUM_NUMBER_OF_PAGES_WITH_RESULTS = 476
 export function getFilterTerm(
   filterField: string,
   value: string | number | boolean | number[] | string[],
-  key: 'terms' | 'term' | 'match' = 'term'
+  key: 'terms' | 'term' | 'match' | 'match_phrase' = 'term'
 ): FilterTerm {
   const isArray = Array.isArray(value)
   const useKey = key === 'term' ? (isArray ? 'terms' : 'term') : key
@@ -334,7 +334,7 @@ export async function getAlgorithmDatasetsForCompute(
       getFilterTerm(
         'service.attributes.main.privacy.publisherTrustedAlgorithms.did',
         algorithmId,
-        'match'
+        'match_phrase'
       )
     ],
     sortOptions: {

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -331,10 +331,12 @@ export async function getAlgorithmDatasetsForCompute(
   const baseQueryParams = {
     chainIds: [datasetChainId],
     filters: [
-      getFilterTerm(
-        'service.attributes.main.privacy.publisherTrustedAlgorithms.did',
-        algorithmId
-      )
+      {
+        match: {
+          'service.attributes.main.privacy.publisherTrustedAlgorithms.did':
+            algorithmId
+        }
+      }
     ],
     sortOptions: {
       sortBy: SortTermOptions.Created,


### PR DESCRIPTION
Fixes #67 

## Proposed Changes

  - replace "term" with "match_phrase" in `getAlgorithmDatasetsForCompute` base query
  - hide algorithms with different service endpoint than dataset in ctd asset actions
