### PR TITLE
Fix: edit metadata crash

### DIFF
--- a/src/components/atoms/Input/InputGroup.module.css
+++ b/src/components/atoms/Input/InputGroup.module.css
@@ -8,6 +8,7 @@
   border-top-right-radius: 0;
   margin-top: -1px;
   width: 100%;
+  box-shadow: none;
 }
 
 .inputGroup button:hover,

--- a/src/components/molecules/FormFields/URLInput/Input.tsx
+++ b/src/components/molecules/FormFields/URLInput/Input.tsx
@@ -25,7 +25,7 @@ export default function URLInput({
   const [buttonDisabled, setButtonDisabled] = useState(true)
 
   useEffect(() => {
-    if (!field?.value) return
+    if (!field?.value || field?.value?.length === 0) return
 
     const isValueValid = isSanitizedUrl(field.value) && !meta.error
 
@@ -43,7 +43,7 @@ export default function URLInput({
 
       <Button
         style="primary"
-        size="small"
+        // size="small"
         onClick={(e: React.SyntheticEvent) => e.preventDefault()}
         disabled={buttonDisabled}
       >

--- a/src/components/molecules/FormFields/URLInput/Input.tsx
+++ b/src/components/molecules/FormFields/URLInput/Input.tsx
@@ -43,7 +43,6 @@ export default function URLInput({
 
       <Button
         style="primary"
-        // size="small"
         onClick={(e: React.SyntheticEvent) => e.preventDefault()}
         disabled={buttonDisabled}
       >


### PR DESCRIPTION
Fixes #89 

## Proposed Changes

  - avoid running url sanitization during metadata editing if sample file field is empty
  - "add file" button is now same height as the input field
