### PR TITLE
Fix: modal close button size

### DIFF
--- a/src/components/molecules/InteractiveModalImage.module.css
+++ b/src/components/molecules/InteractiveModalImage.module.css
@@ -34,12 +34,14 @@
 
 #close:before,
 #close:after {
+  --close-width: 0.125rem;
+
   position: absolute;
   top: 15%;
-  left: calc(50% - 0.0625rem);
-  width: 0.125rem;
+  left: calc(50% - (var(--close-width) / 2));
+  width: var(--close-width);
   height: 70%;
-  border-radius: 0.125rem;
+  border-radius: var(--close-width);
   transform: rotate(45deg);
   background: currentcolor;
   content: '';

--- a/src/components/molecules/InteractiveModalImage.module.css
+++ b/src/components/molecules/InteractiveModalImage.module.css
@@ -8,6 +8,12 @@
   justify-content: center;
   height: 100%;
   cursor: zoom-out;
+  z-index: 4;
+}
+
+.modal img {
+  max-height: 90%;
+  object-fit: contain;
 }
 
 #close {
@@ -17,8 +23,7 @@
   position: relative;
   border: none;
   padding: 0;
-  width: 2em;
-  height: 2em;
+  height: 10%;
   border-radius: 50%;
   background: transparent;
   color: var(--brand-grey);
@@ -31,10 +36,10 @@
 #close:after {
   position: absolute;
   top: 15%;
-  left: calc(50% - 0.0625em);
-  width: 0.125em;
+  left: calc(50% - 0.0625rem);
+  width: 0.125rem;
   height: 70%;
-  border-radius: 0.125em;
+  border-radius: 0.125rem;
   transform: rotate(45deg);
   background: currentcolor;
   content: '';


### PR DESCRIPTION
Fixes #104 

## Proposed Changes

  - image doesn't overflow anymore from the modal window
  - adjust close button size to be visible on all screen sizes

