### PR TITLE
enhancement: move featured assets and hide onboarding section

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -1,4 +1,9 @@
-import React, { ReactElement, useEffect, useState } from 'react'
+import React, {
+  ReactElement,
+  useEffect,
+  useLayoutEffect,
+  useState
+} from 'react'
 import styles from './Home.module.css'
 import AssetList from '../organisms/AssetList'
 import Button from '../atoms/Button'
@@ -25,6 +30,7 @@ import HomeContent from '../organisms/HomeContent'
 import Container from '../atoms/Container'
 import { useAddressConfig } from '../../hooks/useAddressConfig'
 import OnboardingSection from './Home/Onboarding'
+import { useWeb3 } from '../../providers/Web3'
 
 function sortElements(items: DDO[], sorted: string[]) {
   items.sort(function (a, b) {
@@ -106,6 +112,21 @@ export default function HomePage(): ReactElement {
   const [queryLatest, setQueryLatest] = useState<SearchQuery>()
   const { chainIds } = useUserPreferences()
   const { featured, hasFeaturedAssets } = useAddressConfig()
+  const { balance, balanceLoading, web3Loading } = useWeb3()
+  const [showOnboarding, setShowOnboarding] = useState(false)
+
+  useLayoutEffect(() => {
+    const { eth, ocean } = balance
+    if (web3Loading) {
+      setShowOnboarding(false)
+      return
+    }
+    if (!balanceLoading && (eth === '0' || ocean === '0')) {
+      setShowOnboarding(true)
+      return
+    }
+    setShowOnboarding(false)
+  }, [balance, balanceLoading, web3Loading])
 
   useEffect(() => {
     const queryParams = {
@@ -133,9 +154,11 @@ export default function HomePage(): ReactElement {
   return (
     <Permission eventType="browse">
       <>
-        <section className={styles.content}>
-          <OnboardingSection />
-        </section>
+        {showOnboarding && (
+          <section className={styles.content}>
+            <OnboardingSection />
+          </section>
+        )}
         <Container>
           {queryLatest && (
             <SectionQueryResult

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -112,7 +112,7 @@ export default function HomePage(): ReactElement {
   const [queryLatest, setQueryLatest] = useState<SearchQuery>()
   const { chainIds } = useUserPreferences()
   const { featured, hasFeaturedAssets } = useAddressConfig()
-  const { balance, balanceLoading, web3Loading } = useWeb3()
+  const { balance, balanceLoading, chainId, web3Loading } = useWeb3()
   const [showOnboarding, setShowOnboarding] = useState(false)
 
   useLayoutEffect(() => {
@@ -121,12 +121,15 @@ export default function HomePage(): ReactElement {
       setShowOnboarding(false)
       return
     }
-    if (!balanceLoading && (eth === '0' || ocean === '0')) {
+    if (
+      chainId !== 2021000 ||
+      (chainId === 2021000 && !balanceLoading && (eth === '0' || ocean === '0'))
+    ) {
       setShowOnboarding(true)
       return
     }
     setShowOnboarding(false)
-  }, [balance, balanceLoading, web3Loading])
+  }, [balance, balanceLoading, chainId, web3Loading])
 
   useEffect(() => {
     const queryParams = {

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -136,12 +136,6 @@ export default function HomePage(): ReactElement {
         <section className={styles.content}>
           <OnboardingSection />
         </section>
-        <section className={styles.intro}>
-          <HomeIntro />
-        </section>
-        <section className={styles.content}>
-          <HomeContent />
-        </section>
         <Container>
           {queryLatest && (
             <SectionQueryResult
@@ -157,6 +151,12 @@ export default function HomePage(): ReactElement {
             />
           )}
         </Container>
+        <section className={styles.intro}>
+          <HomeIntro />
+        </section>
+        <section className={styles.content}>
+          <HomeContent />
+        </section>
       </>
     </Permission>
   )

--- a/src/providers/Web3.tsx
+++ b/src/providers/Web3.tsx
@@ -32,6 +32,7 @@ interface Web3ProviderValue {
   accountId: string
   accountEns: string
   balance: UserBalance
+  balanceLoading: boolean
   networkId: number
   chainId: number
   networkDisplayName: string
@@ -105,6 +106,7 @@ function Web3Provider({ children }: { children: ReactNode }): ReactElement {
   const [accountId, setAccountId] = useState<string>()
   const [accountEns, setAccountEns] = useState<string>()
   const [web3Loading, setWeb3Loading] = useState<boolean>(true)
+  const [balanceLoading, setBalanceLoading] = useState<boolean>(false)
   const [balance, setBalance] = useState<UserBalance>({
     eth: '0',
     ocean: '0'
@@ -154,6 +156,7 @@ function Web3Provider({ children }: { children: ReactNode }): ReactElement {
   // -----------------------------------
   const getUserBalance = useCallback(async () => {
     if (!accountId || !networkId || !web3) return
+    setBalanceLoading(true)
     const { eth, ocean } = balanceRef.current
 
     try {
@@ -165,6 +168,8 @@ function Web3Provider({ children }: { children: ReactNode }): ReactElement {
       Logger.log('[web3] Balance: ', balance)
     } catch (error) {
       Logger.error('[web3] Error: ', error.message)
+    } finally {
+      setBalanceLoading(false)
     }
   }, [accountId, networkId, web3])
 
@@ -352,6 +357,7 @@ function Web3Provider({ children }: { children: ReactNode }): ReactElement {
         accountId,
         accountEns,
         balance,
+        balanceLoading,
         networkId,
         chainId,
         networkDisplayName,


### PR DESCRIPTION
## Proposed Changes

  - move featured assets list higher on the homepage
  - hide the onboarding section if the user already has both GX and OCEAN tokens
