### PR TITLE
feat: add verified service provider name to asset details page

### DIFF
--- a/src/components/atoms/Publisher/index.module.css
+++ b/src/components/atoms/Publisher/index.module.css
@@ -1,5 +1,6 @@
 .publisher {
   margin: 0;
+  margin-right: 1rem;
 }
 
 @media (min-width: 32rem) {

--- a/src/components/atoms/Publisher/index.tsx
+++ b/src/components/atoms/Publisher/index.tsx
@@ -15,10 +15,12 @@ const cx = classNames.bind(styles)
 export default function Publisher({
   account,
   minimal,
+  verifiedServiceProviderName,
   className
 }: {
   account: string
   minimal?: boolean
+  verifiedServiceProviderName?: string
   className?: string
 }): ReactElement {
   const { accountId } = useWeb3()
@@ -32,6 +34,11 @@ export default function Publisher({
     if (!account) return
 
     const source = axios.CancelToken.source()
+
+    if (verifiedServiceProviderName) {
+      setName(verifiedServiceProviderName)
+      return
+    }
 
     async function getExternalName() {
       // ENS

--- a/src/components/atoms/Publisher/index.tsx
+++ b/src/components/atoms/Publisher/index.tsx
@@ -60,7 +60,7 @@ export default function Publisher({
     return () => {
       source.cancel()
     }
-  }, [account])
+  }, [account, verifiedServiceProviderName])
 
   const styleClasses = cx({
     publisher: true,

--- a/src/components/atoms/VerifiedBadge.module.css
+++ b/src/components/atoms/VerifiedBadge.module.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  min-width: max-content;
 }
 
 .verifiedBadge {

--- a/src/components/atoms/VerifiedBadge.module.css
+++ b/src/components/atoms/VerifiedBadge.module.css
@@ -11,9 +11,12 @@
   padding: calc(var(--spacer) / 3);
   height: calc(var(--spacer) * 1.5);
   border-radius: var(--border-radius);
+  font-weight: var(--font-weight-bold);
+}
+
+.fillBackground {
   background: var(--color-primary);
   color: var(--brand-white);
-  font-weight: var(--font-weight-bold);
 }
 
 .verifiedBadge svg {

--- a/src/components/atoms/VerifiedBadge.module.css
+++ b/src/components/atoms/VerifiedBadge.module.css
@@ -61,3 +61,7 @@
 .isInvalid svg path {
   fill: var(--brand-alert-red);
 }
+
+.loader span {
+  padding: 0;
+}

--- a/src/components/atoms/VerifiedBadge.tsx
+++ b/src/components/atoms/VerifiedBadge.tsx
@@ -4,22 +4,28 @@ import { ReactComponent as VerifiedPatch } from '../../images/patch_check.svg'
 import { ReactComponent as Cross } from '../../images/cross.svg'
 import Time from './Time'
 import styles from './VerifiedBadge.module.css'
+import Loader from './Loader'
 
 const cx = classNames.bind(styles)
 
 export default function VerifiedBadge({
   text,
+  fillBackground,
   className,
   isInvalid,
+  isLoading,
   timestamp
 }: {
   text: string
+  fillBackground?: boolean
   className?: string
   isInvalid?: boolean
+  isLoading?: boolean
   timestamp?: boolean
 }): ReactElement {
   const styleClasses = cx({
     verifiedBadge: true,
+    fillBackground,
     isInvalid,
     timestamp,
     [className]: className
@@ -28,7 +34,7 @@ export default function VerifiedBadge({
   return (
     <div className={styles.container}>
       <div className={styleClasses}>
-        {isInvalid ? <Cross /> : <VerifiedPatch />}
+        {isLoading ? <Loader /> : isInvalid ? <Cross /> : <VerifiedPatch />}
         <span>{text}</span>
         {timestamp && (
           <span className={styles.lastVerified}>

--- a/src/components/atoms/VerifiedBadge.tsx
+++ b/src/components/atoms/VerifiedBadge.tsx
@@ -34,7 +34,15 @@ export default function VerifiedBadge({
   return (
     <div className={styles.container}>
       <div className={styleClasses}>
-        {isLoading ? <Loader /> : isInvalid ? <Cross /> : <VerifiedPatch />}
+        {isLoading ? (
+          <div className={styles.loader}>
+            <Loader />
+          </div>
+        ) : isInvalid ? (
+          <Cross />
+        ) : (
+          <VerifiedPatch />
+        )}
         <span>{text}</span>
         {timestamp && (
           <span className={styles.lastVerified}>

--- a/src/components/atoms/VerifiedPublisher.tsx
+++ b/src/components/atoms/VerifiedPublisher.tsx
@@ -53,7 +53,7 @@ export default function VerifiedPublisher({
       <span>verifying...</span>
     </div>
   ) : verified ? (
-    <VerifiedBadge text="Verified Publisher" />
+    <VerifiedBadge text="Verified Publisher" fillBackground />
   ) : verifyOption ? (
     <div className={styles.verifyButton}>
       <Button

--- a/src/components/molecules/FormFields/URLInput/Input.tsx
+++ b/src/components/molecules/FormFields/URLInput/Input.tsx
@@ -6,7 +6,7 @@ import styles from './Input.module.css'
 import InputGroup from '../../../atoms/Input/InputGroup'
 import isUrl from 'is-url-superb'
 
-const isSanitizedUrl = (url: string): boolean => {
+export const isSanitizedUrl = (url: string): boolean => {
   return url !== '' && isUrl(url) && !url.includes('javascript:')
 }
 

--- a/src/components/organisms/AssetContent/MetaMain.tsx
+++ b/src/components/organisms/AssetContent/MetaMain.tsx
@@ -10,8 +10,14 @@ import styles from './MetaMain.module.css'
 import VerifiedBadge from '../../atoms/VerifiedBadge'
 
 export default function MetaMain(): ReactElement {
-  const { ddo, owner, type, isAssetNetwork, isServiceSelfDescriptionVerified } =
-    useAsset()
+  const {
+    ddo,
+    owner,
+    type,
+    isAssetNetwork,
+    isServiceSelfDescriptionVerified,
+    verifiedServiceProviderName
+  } = useAsset()
   const { web3ProviderInfo } = useWeb3()
 
   const isCompute = Boolean(ddo?.findServiceByType('compute'))
@@ -55,7 +61,11 @@ export default function MetaMain(): ReactElement {
 
       <div className={styles.publisherInfo}>
         <div className={styles.byline}>
-          Published By <Publisher account={owner} />
+          Published By{' '}
+          <Publisher
+            account={owner}
+            verifiedServiceProviderName={verifiedServiceProviderName}
+          />
           <p>
             <Time date={ddo?.created} relative />
             {ddo?.created !== ddo?.updated && (

--- a/src/components/organisms/AssetContent/MetaMain.tsx
+++ b/src/components/organisms/AssetContent/MetaMain.tsx
@@ -16,6 +16,7 @@ export default function MetaMain(): ReactElement {
     type,
     isAssetNetwork,
     isServiceSelfDescriptionVerified,
+    isVerifyingSD,
     verifiedServiceProviderName
   } = useAsset()
   const { web3ProviderInfo } = useWeb3()
@@ -78,8 +79,12 @@ export default function MetaMain(): ReactElement {
             )}
           </p>
         </div>
-        {isServiceSelfDescriptionVerified && (
-          <VerifiedBadge text="Service Self-Description" timestamp />
+        {(isVerifyingSD || isServiceSelfDescriptionVerified) && (
+          <VerifiedBadge
+            text="Service Self-Description"
+            isLoading={isVerifyingSD}
+            timestamp={isServiceSelfDescriptionVerified}
+          />
         )}
       </div>
     </aside>

--- a/src/providers/Asset.tsx
+++ b/src/providers/Asset.tsx
@@ -163,7 +163,7 @@ function AssetProvider({
         setIsServiceSelfDescriptionVerified(
           verified && !!serviceSelfDescriptionContent
         )
-        const serviceProviderName = getPublisherFromServiceSD(
+        const serviceProviderName = await getPublisherFromServiceSD(
           serviceSelfDescriptionContent
         )
         setVerifiedServiceProviderName(serviceProviderName)

--- a/src/providers/Asset.tsx
+++ b/src/providers/Asset.tsx
@@ -20,6 +20,7 @@ import { useAddressConfig } from '../hooks/useAddressConfig'
 import { BestPrice } from '../models/BestPrice'
 import { useCancelToken } from '../hooks/useCancelToken'
 import {
+  getPublisherFromServiceSD,
   getServiceSelfDescription,
   verifyServiceSelfDescription
 } from '../utils/metadata'
@@ -39,6 +40,7 @@ interface AssetProviderValue {
   isAssetNetwork: boolean
   loading: boolean
   isServiceSelfDescriptionVerified: boolean
+  verifiedServiceProviderName: string
   refreshDdo: (token?: CancelToken) => Promise<void>
 }
 
@@ -73,6 +75,8 @@ function AssetProvider({
     isServiceSelfDescriptionVerified,
     setIsServiceSelfDescriptionVerified
   ] = useState<boolean>()
+  const [verifiedServiceProviderName, setVerifiedServiceProviderName] =
+    useState<string>()
   const newCancelToken = useCancelToken()
   const fetchDdo = async (token?: CancelToken) => {
     Logger.log('[asset] Init asset, get DDO')
@@ -170,9 +174,14 @@ function AssetProvider({
       const serviceSelfDescriptionContent = serviceSelfDescription?.url
         ? await getServiceSelfDescription(serviceSelfDescription?.url)
         : serviceSelfDescription?.raw
-      verified && !!serviceSelfDescriptionContent
-        ? setIsServiceSelfDescriptionVerified(true)
-        : setIsServiceSelfDescriptionVerified(false)
+
+      setIsServiceSelfDescriptionVerified(
+        verified && !!serviceSelfDescriptionContent
+      )
+      const serviceProviderName = getPublisherFromServiceSD(
+        serviceSelfDescriptionContent
+      )
+      setVerifiedServiceProviderName(serviceProviderName)
     }
     Logger.log('[asset] Got Metadata from DDO', attributes)
 
@@ -212,7 +221,8 @@ function AssetProvider({
           loading,
           refreshDdo,
           isAssetNetwork,
-          isServiceSelfDescriptionVerified
+          isServiceSelfDescriptionVerified,
+          verifiedServiceProviderName
         } as AssetProviderValue
       }
     >

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -216,6 +216,14 @@ export function updateServiceSelfDescription(
   return ddo
 }
 
+export function getPublisherFromServiceSD(serviceSD: any): string {
+  if (!serviceSD) return
+
+  return serviceSD?.selfDescriptionCredential?.credentialSubject?.[
+    'gx-service-offering:name'
+  ]?.['@value']
+}
+
 export function transformPublishFormToMetadata(
   {
     name,


### PR DESCRIPTION
## Proposed Changes

  - show provider name from a verified SD (if available) in asset details
  - detach metadata loading from service SD verification in asset details page