### PR TITLE
fix: change search on fields back to 'id'

### DIFF
--- a/src/components/templates/Search/utils.ts
+++ b/src/components/templates/Search/utils.ts
@@ -55,7 +55,7 @@ export function getSearchQuery(
       ? '*' + searchTerm + '*'
       : '**'
   const searchFields = [
-    '_id',
+    'id',
     'publicKey.owner',
     'dataToken',
     'dataTokenInfo.name',


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - revert change to `_id` for search queries