### PR TITLE
fix: change default timeout for oceanjs to 10s

### DIFF
--- a/src/providers/Ocean.tsx
+++ b/src/providers/Ocean.tsx
@@ -44,6 +44,7 @@ function OceanProvider({ children }: { children: ReactNode }): ReactElement {
       try {
         Logger.log('[ocean] Connecting Ocean...', newConfig)
         const newOcean = await Ocean.getInstance(newConfig)
+        newOcean.utils.fetch.requestTimeout = 10000
         setOcean(newOcean)
         setConfig(newConfig)
         Logger.log('[ocean] Ocean instance created.', newOcean)


### PR DESCRIPTION
Fixes #194 

## Proposed Changes

  - adjust default timeout value for ocean.js http requests to 10s