### PR TITLE
Fix: duplicate dates in privacy policy

### DIFF
--- a/content/pages/privacy/policies.json
+++ b/content/pages/privacy/policies.json
@@ -3,13 +3,10 @@
     {
       "policy": "en",
       "language": "English",
-      "date": "2022-03-24",
       "params": {
         "languageLabel": "Language",
         "languageHelp": "Language of the privacy policy",
-        "tocHeader": "Table of contents",
-        "updated": "Last updated on",
-        "dateFormat": "MM/dd/yyyy"
+        "tocHeader": "Table of contents"
       }
     }
   ]

--- a/src/components/molecules/PrivacyHeader.tsx
+++ b/src/components/molecules/PrivacyHeader.tsx
@@ -18,10 +18,6 @@ export default function PrivacyPolicyHeader({
   return (
     <div>
       <PrivacyLanguages label={params.languageLabel} />
-      <p>
-        {params?.updated || 'Last updated on'}{' '}
-        <Time date={date} displayFormat={params?.dateFormat || 'MM-dd-yyyy'} />
-      </p>
       <div className={styles.content}>
         <h1>{params?.tocHeader || 'Table of Contents'}</h1>
         <div

--- a/src/hooks/usePrivacyMetadata.ts
+++ b/src/hooks/usePrivacyMetadata.ts
@@ -4,12 +4,9 @@ export interface UsePrivacyMetadata {
   policies: {
     policy: string
     language: string
-    date: string
     params: {
       languageLabel: string
       tocHeader: string
-      updated: string
-      dateFormat: string
     }
   }[]
 }
@@ -19,11 +16,8 @@ const query = graphql`
     privacyJson {
       policies {
         policy
-        date
         language
         params {
-          updated
-          dateFormat
           tocHeader
           languageLabel
         }

--- a/tests/unit/__fixtures__/privacyMetadata.json
+++ b/tests/unit/__fixtures__/privacyMetadata.json
@@ -3,11 +3,8 @@
     "policies": [
       {
         "policy": "en",
-        "date": "2021-07-31",
         "language": "English",
         "params": {
-          "updated": "Last updated on",
-          "dateFormat": "MM/dd/yyyy",
           "tocHeader": "Table of contents",
           "languageLabel": "Language"
         }


### PR DESCRIPTION
## Proposed Changes

  - remove dates from policies.json
  - (every policy markdown should just include the last updated date)
