### PR TITLE
enhancement: remove price creation warning for "thing" type assets

### DIFF
--- a/src/components/organisms/AssetContent/index.tsx
+++ b/src/components/organisms/AssetContent/index.tsx
@@ -83,9 +83,9 @@ export default function AssetContent(props: AssetContentProps): ReactElement {
 
     const isOwner = accountId.toLowerCase() === owner.toLowerCase()
     setIsOwner(isOwner)
-    setShowPricing(isOwner && price?.type === '')
+    setShowPricing(isOwner && type !== 'thing' && price?.type === '')
     setIsComputeType(Boolean(ddo.findServiceByType('compute')))
-  }, [accountId, price, owner, ddo])
+  }, [accountId, price, owner, ddo, type])
 
   function handleEditButton() {
     // move user's focus to top of screen


### PR DESCRIPTION
Fixes #221

## Proposed Changes

  - remove pricing flow from AssetDetails for `thing` assets type
