### PR TITLE
fix: default tab selection in profile page

### DIFF
--- a/src/components/atoms/Tabs.tsx
+++ b/src/components/atoms/Tabs.tsx
@@ -9,19 +9,22 @@ interface TabsItem {
 
 export default function Tabs({
   items,
+  selectedIndex,
+  setSelectedIndex,
   className,
-  handleTabChange,
-  defaultIndex
+  handleTabChange
 }: {
   items: TabsItem[]
+  selectedIndex: number
+  setSelectedIndex: (index: number) => void
   className?: string
   handleTabChange?: (tabName: string) => void
-  defaultIndex?: number
 }): ReactElement {
   return (
     <ReactTabs
       className={`${className && className}`}
-      defaultIndex={defaultIndex}
+      selectedIndex={selectedIndex}
+      onSelect={(e) => setSelectedIndex(e)}
     >
       <TabList className={styles.tabList}>
         {items.map((item) => (

--- a/src/components/organisms/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/organisms/AssetActions/Compute/FormComputeDataset.tsx
@@ -103,7 +103,8 @@ export default function FormStartCompute({
 
   const { isValid, values }: FormikContextType<{ algorithm: string }> =
     useFormikContext()
-  const { price, ddo, isAssetNetwork, isEdgeCtdAvailable } = useAsset()
+  const { price, ddo, isAssetNetwork, isEdgeAsset, isEdgeCtdAvailable } =
+    useAsset()
   const [totalPrice, setTotalPrice] = useState(price?.value)
   const [isBalanceSufficient, setIsBalanceSufficient] = useState<boolean>(false)
   const { accountId, balance } = useWeb3()
@@ -210,7 +211,7 @@ export default function FormStartCompute({
           !isBalanceSufficient ||
           !isAssetNetwork ||
           algorithmConsumableStatus > 0 ||
-          !isEdgeCtdAvailable
+          (isEdgeAsset && !isEdgeCtdAvailable)
         }
         hasPreviousOrder={hasPreviousOrder}
         hasDatatoken={hasDatatoken}
@@ -238,7 +239,7 @@ export default function FormStartCompute({
         isConsumable={isConsumable}
         consumableFeedback={consumableFeedback}
         algorithmConsumableStatus={algorithmConsumableStatus}
-        isEdgeDeviceUnavailable={!isEdgeCtdAvailable}
+        isEdgeDeviceUnavailable={isEdgeAsset && !isEdgeCtdAvailable}
       />
     </Form>
   )

--- a/src/components/pages/Profile/History/index.tsx
+++ b/src/components/pages/Profile/History/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useEffect, useState } from 'react'
 import Tabs from '../../../atoms/Tabs'
 import PublishedList from './PublishedList'
 import Downloads from './Downloads'
@@ -47,15 +47,29 @@ export default function HistoryPage({
 }): ReactElement {
   const { accountId } = useWeb3()
   const location = useLocation()
+  const [tabs, setTabs] = useState<HistoryTab[]>([])
+  const [selectedIndex, setSelectedIndex] = useState<number>(0)
 
   const url = new URL(location.href)
   const defaultTab = url.searchParams.get('defaultTab')
-  const tabs = getTabs(accountIdentifier, accountId)
 
-  let defaultTabIndex = 0
-  defaultTab === 'ComputeJobs' ? (defaultTabIndex = 4) : (defaultTabIndex = 0)
+  useEffect(() => {
+    const tabs = getTabs(accountIdentifier, accountId)
+    setTabs(tabs)
+
+    const defaultTabIndex = tabs.findIndex(
+      (tab) =>
+        tab.title.split(' ').join('').toLowerCase() === defaultTab.toLowerCase()
+    )
+    setSelectedIndex(defaultTabIndex !== -1 ? defaultTabIndex : 0)
+  }, [accountId, accountIdentifier, defaultTab])
 
   return (
-    <Tabs items={tabs} className={styles.tabs} defaultIndex={defaultTabIndex} />
+    <Tabs
+      items={tabs}
+      className={styles.tabs}
+      selectedIndex={selectedIndex}
+      setSelectedIndex={setSelectedIndex}
+    />
   )
 }

--- a/src/components/pages/Profile/History/index.tsx
+++ b/src/components/pages/Profile/History/index.tsx
@@ -59,7 +59,8 @@ export default function HistoryPage({
 
     const defaultTabIndex = tabs.findIndex(
       (tab) =>
-        tab.title.split(' ').join('').toLowerCase() === defaultTab.toLowerCase()
+        tab.title.split(' ').join('').toLowerCase() ===
+        defaultTab?.toLowerCase()
     )
     setSelectedIndex(defaultTabIndex !== -1 ? defaultTabIndex : 0)
   }, [accountId, accountIdentifier, defaultTab])


### PR DESCRIPTION
Fixes #222

## Proposed Changes

  - open profile page at the correct tab if specified in the url
  - show the "edge ctd device not available" warning only for edge assets