### PR TITLE
enhancement: add moveID portal to ecosystem dropdown

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -27,6 +27,10 @@
             "link": "https://euprogigant.portal.minimal-gaia-x.eu"
           },
           {
+            "name": "moveID",
+            "link": "https://portal.moveid.eu"
+          },
+          {
             "name": "Future Mobility",
             "link": "https://marketplace.future-mobility-alliance.org"
           }


### PR DESCRIPTION
Fixes #230

Currently the link is broken, do not merge until the moveID portal is deployed

## Proposed Changes

- add moveID portal as second entry in dropdown