### PR TITLE
fix: restore webpack size plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -89,6 +89,7 @@ module.exports = {
         display: 'standalone',
         cache_busting_mode: 'none'
       }
-    }
+    },
+    'gatsby-plugin-webpack-size'
   ]
 }


### PR DESCRIPTION
## Proposed Changes

  - restore webpack size plugin in gatsby config
