### PR TITLE
Fix: query for algo's compatible datasets 

### DIFF
--- a/src/@utils/aquarius/index.ts
+++ b/src/@utils/aquarius/index.ts
@@ -255,7 +255,7 @@ export async function getAlgorithmDatasetsForCompute(
     chainIds: [datasetChainId],
     nestedQuery: {
       must: {
-        match: {
+        match_phrase: {
           'services.compute.publisherTrustedAlgorithms.did': {
             query: algorithmId
           }


### PR DESCRIPTION
## Proposed Changes

  - replace `match` with `match_phrase` in `getAlgorithmDatasetsForCompute` base query
