### PR TITLE
feat: price output

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jamiehewitt15 @mihaisc @kremalicious @bogdanfazakas @EnzoVezzaro
+* @moritzkirstein @LucaMilanese90

--- a/src/components/@shared/Price/PriceUnit.tsx
+++ b/src/components/@shared/Price/PriceUnit.tsx
@@ -8,21 +8,23 @@ export default function PriceUnit({
   className,
   size = 'small',
   symbol,
-  decimals
+  decimals,
+  explicitZero
 }: {
   price: number
   className?: string
   size?: 'small' | 'mini' | 'large'
   symbol?: string
   decimals?: string
+  explicitZero?: boolean
 }): ReactElement {
   const { locale } = useUserPreferences()
 
   return (
     <div className={`${styles.price} ${styles[size]} ${className}`}>
-      {price === 0 ? (
+      {price === 0 && !explicitZero ? (
         <div>Free</div>
-      ) : !price || Number.isNaN(price) ? (
+      ) : (!price && price !== 0) || Number.isNaN(price) ? (
         <div>-</div>
       ) : (
         <div>

--- a/src/components/Asset/AssetActions/Compute/PriceOutput.tsx
+++ b/src/components/Asset/AssetActions/Compute/PriceOutput.tsx
@@ -5,7 +5,6 @@ import Tooltip from '@shared/atoms/Tooltip'
 import styles from './PriceOutput.module.css'
 import { MAX_DECIMALS } from '@utils/constants'
 import Decimal from 'decimal.js'
-import { useWeb3 } from '@context/Web3'
 
 interface PriceOutputProps {
   hasPreviousOrder: boolean
@@ -52,6 +51,7 @@ function Row({
           symbol={symbol}
           size="small"
           className={styles.price}
+          explicitZero
         />
         <span className={styles.timeout}>
           {timeout &&
@@ -90,11 +90,11 @@ export default function PriceOutput({
         <div key={item.symbol}>
           <PriceUnit
             price={Number(item.value)}
-            symbol={
-              index < totalPrices.length - 1 ? `${item.symbol} & ` : item.symbol
-            }
+            symbol={item.symbol}
             size="small"
+            explicitZero
           />
+          {index < totalPrices.length - 1 && <>&nbsp;{'&'}&nbsp;</>}
         </div>
       ))}
       <Tooltip


### PR DESCRIPTION
## Proposed Changes

  - fix missing spacing between tokens on the asset detail page
  - explicitly display prices equal to `0` instead of `free` for the asset detail page
