### PR TITLE
fix: get compute algo list for assets with multiple trusted algo publishers

### DIFF
--- a/src/@utils/compute.ts
+++ b/src/@utils/compute.ts
@@ -169,7 +169,12 @@ export function getQueryString(
   algorithmDidList?.length > 0 &&
     baseParams.filters.push(getFilterTerm('_id', algorithmDidList))
   trustedPublishersList?.length > 0 &&
-    baseParams.filters.push(getFilterTerm('nft.owner', trustedPublishersList))
+    baseParams.filters.push(
+      getFilterTerm(
+        'nft.owner',
+        trustedPublishersList.map((address) => address.toLowerCase())
+      )
+    )
   const query = generateBaseQuery(baseParams)
 
   return query


### PR DESCRIPTION
Fixes #388

