### PR TITLE
feat: terms and conditions checkbox for download and saas assets

### DIFF
--- a/src/components/Asset/AssetActions/Download/_validation.ts
+++ b/src/components/Asset/AssetActions/Download/_validation.ts
@@ -6,8 +6,12 @@ export function getDownloadValidationSchema(
   parameters: ConsumerParameter[]
 ): Yup.SchemaOf<{
   dataServiceParams: any
+  termsAndConditions: boolean
 }> {
   return Yup.object().shape({
-    dataServiceParams: getUserCustomParameterValidationSchema(parameters)
+    dataServiceParams: getUserCustomParameterValidationSchema(parameters),
+    termsAndConditions: Yup.boolean()
+      .required('Required')
+      .isTrue('Please agree to the Terms and Conditions.')
   })
 }

--- a/src/components/Asset/AssetActions/Download/index.module.css
+++ b/src/components/Asset/AssetActions/Download/index.module.css
@@ -21,6 +21,11 @@
   flex-shrink: 0;
 }
 
+.consumerParameters > div {
+  margin-top: var(--spacer);
+  border-bottom: none;
+}
+
 .price {
   align-self: center;
 }

--- a/src/components/Asset/AssetActions/Download/index.module.css
+++ b/src/components/Asset/AssetActions/Download/index.module.css
@@ -13,6 +13,10 @@
   justify-content: flex-start;
 }
 
+.priceWrapper > div:last-of-type {
+  margin-bottom: 0;
+}
+
 .filewrapper {
   flex-shrink: 0;
 }

--- a/src/components/Asset/AssetActions/Download/index.tsx
+++ b/src/components/Asset/AssetActions/Download/index.tsx
@@ -30,12 +30,13 @@ import useNetworkMetadata from '@hooks/useNetworkMetadata'
 import ConsumerParameters, {
   parseConsumerParameterValues
 } from '../ConsumerParameters'
-import { Form, Formik, useFormikContext } from 'formik'
+import { Field, Form, Formik, useFormikContext } from 'formik'
 import { getDownloadValidationSchema } from './_validation'
 import { getDefaultValues } from '../ConsumerParameters/FormConsumerParameters'
 import WhitelistIndicator from '../Compute/WhitelistIndicator'
 import { Signer } from 'ethers'
 import SuccessConfetti from '@components/@shared/SuccessConfetti'
+import Input from '@components/@shared/FormInput'
 
 export default function Download({
   accountId,
@@ -287,6 +288,15 @@ export default function Download({
                   <ConsumerParameters asset={asset} isLoading={isLoading} />
                 )}
                 {!isInPurgatory && <PurchaseButton isValid={isValid} />}
+                <Field
+                  component={Input}
+                  name="termsAndConditions"
+                  type="checkbox"
+                  options={['Terms and Conditions']}
+                  prefixes={['I agree to the']}
+                  actions={['/terms']}
+                  disabled={isLoading}
+                />
               </div>
             )}
           </>
@@ -300,8 +310,10 @@ export default function Download({
       initialValues={{
         dataServiceParams: getDefaultValues(
           asset?.services[0].consumerParameters
-        )
+        ),
+        termsAndConditions: false
       }}
+      validateOnMount
       validationSchema={getDownloadValidationSchema(
         asset?.services[0].consumerParameters
       )}

--- a/src/components/Asset/AssetActions/Download/index.tsx
+++ b/src/components/Asset/AssetActions/Download/index.tsx
@@ -284,9 +284,6 @@ export default function Download({
                     size="large"
                   />
                 )}
-                {asset && (
-                  <ConsumerParameters asset={asset} isLoading={isLoading} />
-                )}
                 {!isInPurgatory && <PurchaseButton isValid={isValid} />}
                 <Field
                   component={Input}
@@ -338,6 +335,11 @@ export default function Download({
               />
             </div>
             <AssetAction asset={asset} />
+          </div>
+          <div className={styles.consumerParameters}>
+            {asset && (
+              <ConsumerParameters asset={asset} isLoading={isLoading} />
+            )}
           </div>
           {isOwned && (
             <div className={styles.confettiContainer}>


### PR DESCRIPTION
## Proposed Changes

  - feat: add T&C checkbox to `download` and `saas` asset actions
  - fix: consume parameter form alignment for `download` and `saas` assets
