### PR TITLE
Use select options value and label

### DIFF
--- a/src/components/@shared/FormInput/InputElement/index.tsx
+++ b/src/components/@shared/FormInput/InputElement/index.tsx
@@ -84,8 +84,8 @@ const InputElement = forwardRef(
         const sortedOptions =
           !sortOptions && sortOptions === false
             ? options
-            : (options as string[]).sort((a: string, b: string) =>
-                a.localeCompare(b)
+            : (options as string[]).sort((a: any, b: any) =>
+                a.label.localeCompare(b.label)
               )
         return (
           <select
@@ -96,17 +96,11 @@ const InputElement = forwardRef(
           >
             {field !== undefined && field.value === '' && <option value="" />}
             {sortedOptions &&
-              (sortedOptions as string[]).map(
-                (option: string, index: number) => (
-                  <option key={index} value={option}>
-                    <Option
-                      option={option}
-                      prefix={prefixes?.[index]}
-                      postfix={postfixes?.[index]}
-                    />
-                  </option>
-                )
-              )}
+              (sortedOptions as any[]).map((option, index: number) => (
+                <option key={index} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
           </select>
         )
       }

--- a/src/components/Asset/AssetActions/ConsumerParameters/FormConsumerParameters.tsx
+++ b/src/components/Asset/AssetActions/ConsumerParameters/FormConsumerParameters.tsx
@@ -44,7 +44,12 @@ export default function FormConsumerParameters({
       parameter.type === 'boolean'
         ? ['true', 'false']
         : parameter.type === 'select'
-        ? JSON.parse(parameter.options)?.map((option) => Object.keys(option)[0])
+        ? JSON.parse(parameter.options)?.map((option) => {
+            return {
+              value: Object.keys(option)[0],
+              label: Object.values(option)[0]
+            }
+          })
         : []
 
     // add empty option, if parameter is optional


### PR DESCRIPTION
Fixes issue with user input when using a "select". The options labels were not being used, just the values.

## Proposed Changes

  - Retrieve both value and label from parameter options
  - Use value and label when generating the InputElement, producing a better UX