### PR TITLE
Fix: catalogue list view crash

### DIFF
--- a/src/@types/AssetExtended.d.ts
+++ b/src/@types/AssetExtended.d.ts
@@ -1,4 +1,4 @@
-import { Asset } from '@oceanprotocol/lib'
+import { Asset, Metadata } from '@oceanprotocol/lib'
 
 // declaring into global scope to be able to use this as
 // ambiant types despite the above imports
@@ -6,7 +6,7 @@ declare global {
   interface AssetExtended extends Asset {
     accessDetails?: AccessDetails
     views?: number
-    metadata: MetadataExtended
+    metadata: Metadata
     services: ServiceExtended[]
   }
 }

--- a/src/components/@shared/AssetList/index.tsx
+++ b/src/components/@shared/AssetList/index.tsx
@@ -35,8 +35,10 @@ const columns: TableOceanColumn<AssetExtended>[] = [
       return (
         <AssetType
           className={styles.typeLabel}
-          type={metadata.additionalInformation.saas ? 'saas' : metadata.type}
-          accessType={metadata.additionalInformation.saas ? 'saas' : accessType}
+          type={metadata.additionalInformation?.saas ? 'saas' : metadata.type}
+          accessType={
+            metadata.additionalInformation?.saas ? 'saas' : accessType
+          }
         />
       )
     },


### PR DESCRIPTION
Fixes a crash when switching to list view in catalogue page

Also removes outdated MetadataExtended type, as typings now are supported by ocean.js
