### PR TITLE
docs: update announcement text (load testing)

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "announcement": "The GEN-X network is deprecated and will be sunset on September 30, 2024. Please [migrate to the Pontus-X networks](https://docs.pontus-x.eu/docs/use-cases/migration-guide).",
+  "announcement": "The Pontus-X Devnet is currently undergoing a scheduled load test. The network remains stable and fully operational during this period.",
   "devPreviewAnnouncement": "You are visiting the SITE-TITLE-PLACEHOLDER Developer Preview. Please note that some functionalities are in beta and may not work as expected. Visit the [SITE-TITLE-PLACEHOLDER portal](SITE-LINK-PLACEHOLDER) instead.",
   "warning": {
     "ctd": "Please note that Compute-to-Data is still in alpha phase."


### PR DESCRIPTION
## Proposed Changes

  - Remove GEN-X deprecation text as it's outdated
  - Add announcement about the load test on Pontus-X Devnet
