### PR TITLE
fix: show address as provider if the address is not in pontusxAddresses.json

### DIFF
--- a/src/components/@shared/Publisher/index.tsx
+++ b/src/components/@shared/Publisher/index.tsx
@@ -30,7 +30,7 @@ export default function Publisher({
 
     // set default name on hook
     // to avoid side effect (UI not updating on account's change)
-    if (showName && isMounted()) {
+    if (showName && isMounted() && addresses[account]) {
       const accountName = addresses[account]
       accountName.length > 15
         ? setName(accountTruncate(accountName, 15))


### PR DESCRIPTION
Fixes #
- shows the address instead of the name if the name is not available
