### PR TITLE
fix: support 'Pay per use' payment mode in asset actions

### DIFF
--- a/src/components/Asset/AssetActions/ButtonBuy/index.tsx
+++ b/src/components/Asset/AssetActions/ButtonBuy/index.tsx
@@ -33,7 +33,7 @@ export interface ButtonBuyProps {
   isAccountConnected?: boolean
   hasProviderFee?: boolean
   retry?: boolean
-  paymentMode?: PaymentMode
+  paymentMode?: PaymentMode | 'Pay per use'
 }
 
 function getConsumeHelpText(
@@ -194,7 +194,7 @@ export default function ButtonBuy({
     ? 'Retry'
     : action === 'download'
     ? hasPreviousOrder && assetType === 'saas'
-      ? paymentMode === PAYMENT_MODES.PAYPERUSE
+      ? paymentMode === PAYMENT_MODES.PAYPERUSE || paymentMode === 'Pay per use'
         ? `Buy access credit`
         : 'Go to service'
       : hasPreviousOrder
@@ -202,7 +202,7 @@ export default function ButtonBuy({
       : priceType === 'free'
       ? 'Get'
       : assetType === 'saas'
-      ? paymentMode === PAYMENT_MODES.PAYPERUSE
+      ? paymentMode === PAYMENT_MODES.PAYPERUSE || paymentMode === 'Pay per use'
         ? `Buy access credit`
         : `Subscribe ${
             assetTimeout === 'Forever' ? '' : ` for ${assetTimeout}`

--- a/src/components/Asset/AssetActions/Download/ContractingProvider/index.tsx
+++ b/src/components/Asset/AssetActions/Download/ContractingProvider/index.tsx
@@ -70,6 +70,7 @@ export default function ContractingProvider(props: {
       signature,
       did
     )
+    console.log('count', count)
     setAccessCreditsCount(count)
     setIsRequesting(false)
   }, [contractingProviderEndpoint, activeAddress, signature, did])
@@ -88,7 +89,7 @@ export default function ContractingProvider(props: {
 
   return (
     <div className={styles.container}>
-      {accessCreditsCount ? (
+      {typeof accessCreditsCount !== 'undefined' ? (
         <Alert
           state="info"
           text={`You purchased access to this service **${accessCreditsCount} time${

--- a/src/components/Asset/AssetActions/Download/index.tsx
+++ b/src/components/Asset/AssetActions/Download/index.tsx
@@ -311,8 +311,10 @@ export default function Download({
                 )}
                 {!isInPurgatory && (
                   <>
-                    {asset?.metadata?.additionalInformation?.saas
-                      ?.paymentMode === PAYMENT_MODES.PAYPERUSE &&
+                    {(asset?.metadata?.additionalInformation?.saas
+                      ?.paymentMode === PAYMENT_MODES.PAYPERUSE ||
+                      asset?.metadata?.additionalInformation?.saas
+                        ?.paymentMode === 'Pay per use') &&
                       asset?.metadata?.additionalInformation?.saas
                         ?.redirectUrl && (
                         <div className={styles.payPerUseBtn}>
@@ -411,8 +413,10 @@ export default function Download({
             />
           )}
           {isContractingFeatureEnabled &&
-            asset?.metadata?.additionalInformation?.saas?.paymentMode ===
-              PAYMENT_MODES.PAYPERUSE &&
+            (asset?.metadata?.additionalInformation?.saas?.paymentMode ===
+              PAYMENT_MODES.PAYPERUSE ||
+              asset?.metadata?.additionalInformation?.saas?.paymentMode ===
+                'Pay per use') &&
             accountId &&
             isAccountIdWhitelisted && <ContractingProvider did={asset.id} />}
           {accountId && (


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Pay-per-use interface is displayed if `paymentMode` is `‘Pay per use’` or `‘payperuse’`.
  - Access count is always displayed
