### PR TITLE
Add Inspirators

### DIFF
--- a/pontusxAddresses.json
+++ b/pontusxAddresses.json
@@ -674,5 +674,6 @@
   "0x20d5f579f9b4a070c14Cc9AAB4663500f3B94022": "Airbus Defense and Space GmbH",
   "0x270c3fcbc466ea28862f2b6c332f14360d9a19aa": "Functional Simulation aaS",
   "0xd163c99ec1b16d704060a6903793691ae6fee983": "Magnetic Torquer",
-  "0x83253572e146aD1b66e631280BC573f5C39c0163": "neusta aerospace GmbH"
+  "0x83253572e146aD1b66e631280BC573f5C39c0163": "neusta aerospace GmbH",
+  "0x599Eb75866526822Df3fb32241506bDd3bA5F22E": "Inspirators! OÜ"
 }


### PR DESCRIPTION
Inspirators! OÜ
Mäealuse tn 2/1,
Tallinn, 12618
Estonia

Public Address: 0x599Eb75866526822Df3fb32241506bDd3bA5F22E

Company Registration No.: 16224196, 
VatID: EE102369555,
Website: https://inspirators.eu/
