### PR TITLE
fix: license on compute publish preview

### DIFF
--- a/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
@@ -55,7 +55,8 @@ export default function FormStartCompute({
   algoOrderPriceAndFees,
   providerFeeAmount,
   validUntil,
-  retry
+  retry,
+  license
 }: {
   algorithms: AssetSelectionAsset[]
   ddoListAlgorithms: Asset[]
@@ -92,6 +93,7 @@ export default function FormStartCompute({
   providerFeeAmount?: string
   validUntil?: string
   retry: boolean
+  license: string
 }): ReactElement {
   const { address: accountId, isConnected } = useAccount()
   const { balance } = useBalance()
@@ -407,7 +409,7 @@ export default function FormStartCompute({
       />
       <TermsAndConditionsCheckbox
         {...content.form.assetTermsAndConditions}
-        licenses={[asset?.metadata?.license]}
+        licenses={[license]}
         disabled={isLoading}
         onChange={() =>
           setAssetTermsAndConditions(

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -630,6 +630,7 @@ export default function Compute({
             providerFeeAmount={providerFeeAmount}
             validUntil={computeValidUntil}
             retry={retry}
+            license={asset?.metadata?.license}
           />
         </Formik>
       )}

--- a/src/components/Asset/AssetActions/TermsAndConditionsCheckbox.tsx
+++ b/src/components/Asset/AssetActions/TermsAndConditionsCheckbox.tsx
@@ -26,12 +26,12 @@ export default function TermsAndConditionsCheckbox({
       options={
         options ||
         licenses?.map((option) =>
-          option?.includes('http') ? 'a custom' : `the ${option}`
+          option.includes('http') ? 'a custom' : `the ${option}`
         )
       }
       prefixes={prefixes}
       postfixes={postfixes}
-      actions={licenses?.filter((action) => action?.includes('http'))}
+      actions={licenses?.filter((action) => action.includes('http'))}
       component={Input}
       disabled={disabled}
       {...(onChange && { onChange })}

--- a/src/components/Asset/AssetActions/TermsAndConditionsCheckbox.tsx
+++ b/src/components/Asset/AssetActions/TermsAndConditionsCheckbox.tsx
@@ -25,13 +25,13 @@ export default function TermsAndConditionsCheckbox({
       type="checkbox"
       options={
         options ||
-        licenses.map((option) =>
-          option.includes('http') ? 'a custom' : `the ${option}`
+        licenses?.map((option) =>
+          option?.includes('http') ? 'a custom' : `the ${option}`
         )
       }
       prefixes={prefixes}
       postfixes={postfixes}
-      actions={licenses?.filter((action) => action.includes('http'))}
+      actions={licenses?.filter((action) => action?.includes('http'))}
       component={Input}
       disabled={disabled}
       {...(onChange && { onChange })}


### PR DESCRIPTION
when publishing a compute asset, the app crashed during the preview

## Proposed Changes

  - hand over the license as `prop` to `FormComputeDataset.tsx`
