### PR TITLE
feat: add SaaS type on publish with separate redirect URL and paymentmode fields

### DIFF
--- a/content/publish/form.json
+++ b/content/publish/form.json
@@ -13,7 +13,7 @@
         "name": "type",
         "label": "Asset Type",
         "type": "boxSelection",
-        "options": ["Dataset", "Algorithm"],
+        "options": ["Dataset", "Algorithm", "SaaS"],
         "required": true
       },
       {
@@ -167,6 +167,25 @@
         "required": true
       },
       {
+        "name": "redirectUrl",
+        "title": "Redirect URL",
+        "label": "Redirect URL",
+        "placeholder": "e.g. https://delta-dao/the-future-is-now",
+        "help": "The url the user will be redirected to after buying access to the Software as a Service offering.",
+        "type": "saas",
+        "required": true
+      },
+      {
+        "name": "paymentMode",
+        "title": "PaymentMode",
+        "label": "PaymentMode",
+        "help": "Choose the payment mode of your Software as a Service offering.",
+        "type": "select",
+        "selected": "",
+        "options": ["Subscription", "Pay per use"],
+        "required": true
+      },
+      {
         "name": "files",
         "label": "File",
         "prominentHelp": false,
@@ -204,30 +223,6 @@
                 "help": "This HEADERS will be stored encrypted after publishing.",
                 "type": "headers",
                 "required": false
-              }
-            ]
-          },
-          {
-            "value": "saas",
-            "title": "SaaS",
-            "label": "Redirect URL",
-            "placeholder": "e.g. https://delta-dao/the-future-is-now",
-            "help": "The url the user will be redirected to after buying access to the Software as a Service offering.",
-            "prominentHelp": true,
-            "type": "saas",
-            "fieldFormPrefix": "metadata.saas",
-            "required": true,
-            "methods": false,
-            "innerFields": [
-              {
-                "value": "paymentMode",
-                "title": "PaymentMode",
-                "label": "PaymentMode",
-                "help": "Choose the payment mode of your Software as a Service offering.",
-                "type": "select",
-                "selected": "",
-                "options": ["Subscription", "Pay per use"],
-                "required": true
               }
             ]
           },

--- a/src/components/Publish/Metadata/index.tsx
+++ b/src/components/Publish/Metadata/index.tsx
@@ -7,6 +7,7 @@ import consumerParametersContent from '../../../../content/publish/consumerParam
 import { FormPublishData } from '../_types'
 import IconDataset from '@images/dataset.svg'
 import IconAlgorithm from '@images/algorithm.svg'
+import IconSaas from '@images/saas.svg'
 import styles from './index.module.css'
 import { algorithmContainerPresets } from '../_constants'
 import { useMarketMetadata } from '@context/MarketMetadata'
@@ -31,7 +32,9 @@ export default function MetadataFields(): ReactElement {
     {
       name: assetTypeOptionsTitles[0].toLowerCase(),
       title: assetTypeOptionsTitles[0],
-      checked: values.metadata.type === assetTypeOptionsTitles[0].toLowerCase(),
+      checked:
+        values.metadata.type === assetTypeOptionsTitles[0].toLowerCase() &&
+        values.services[0]?.files[0]?.type !== 'saas',
       icon: <IconDataset />
     },
     {
@@ -39,6 +42,14 @@ export default function MetadataFields(): ReactElement {
       title: assetTypeOptionsTitles[1],
       checked: values.metadata.type === assetTypeOptionsTitles[1].toLowerCase(),
       icon: <IconAlgorithm />
+    },
+    {
+      name: assetTypeOptionsTitles[2].toLowerCase(),
+      title: assetTypeOptionsTitles[2],
+      checked:
+        values.metadata.type === assetTypeOptionsTitles[0].toLowerCase() &&
+        values.services[0]?.files[0]?.type === 'saas',
+      icon: <IconSaas />
     }
   ]
 
@@ -76,6 +87,15 @@ export default function MetadataFields(): ReactElement {
         component={Input}
         name="metadata.type"
         options={assetTypeOptions}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          if (event.target.value === 'saas') {
+            setFieldValue('metadata.type', 'dataset')
+            setFieldValue('services[0].files[0].type', 'saas')
+          } else {
+            setFieldValue('services[0].files[0].type', 'url')
+            setFieldValue('metadata.type', event.target.value)
+          }
+        }}
       />
       <Field
         {...getFieldContent('name', content.metadata.fields)}

--- a/src/components/Publish/Services/index.tsx
+++ b/src/components/Publish/Services/index.tsx
@@ -82,11 +82,26 @@ export default function ServicesFields(): ReactElement {
         component={Input}
         name="services[0].providerUrl"
       />
-      <Field
-        {...getFieldContent('files', content.services.fields)}
-        component={Input}
-        name="services[0].files"
-      />
+      {values.services[0]?.files[0]?.type === 'saas' ? (
+        <>
+          <Field
+            {...getFieldContent('redirectUrl', content.services.fields)}
+            component={Input}
+            name="services[0].files[0].url"
+          />
+          <Field
+            {...getFieldContent('paymentMode', content.services.fields)}
+            component={Input}
+            name="metadata.saas.paymentMode"
+          />
+        </>
+      ) : (
+        <Field
+          {...getFieldContent('files', content.services.fields)}
+          component={Input}
+          name="services[0].files"
+        />
+      )}
       <Field
         {...getFieldContent('links', content.services.fields)}
         component={Input}

--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -11,7 +11,7 @@ import { validationConsumerParameters } from '@components/@shared/FormInput/Inpu
 
 const validationMetadata = {
   type: Yup.string()
-    .matches(/dataset|algorithm/g, { excludeEmptyString: true })
+    .matches(/dataset|algorithm|saas/g, { excludeEmptyString: true })
     .required('Required'),
   name: Yup.string()
     .min(4, (param) => `Title must be at least ${param.min} characters`)


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - add SaaS type on publish
  - SaaS is removed from the Dataset publish flow
  - added separate redirect URL and paymentmode fields on SaaS publish flow
