### PR TITLE
fix: do not use consumer parameters with empty values

### DIFF
--- a/src/components/Asset/AssetActions/ConsumerParameters/index.tsx
+++ b/src/components/Asset/AssetActions/ConsumerParameters/index.tsx
@@ -19,14 +19,16 @@ export function parseConsumerParameterValues(
       (param) => param.name === userCustomParameterKey
     )
 
-    Object.assign(parsedValues, {
-      [userCustomParameterKey]:
-        type === 'select' && userCustomParameterValue === ''
-          ? undefined
-          : type === 'boolean'
-          ? userCustomParameterValue === 'true'
-          : userCustomParameterValue
-    })
+    if (userCustomParameterValue) {
+      Object.assign(parsedValues, {
+        [userCustomParameterKey]:
+          type === 'select' && userCustomParameterValue === ''
+            ? undefined
+            : type === 'boolean'
+            ? userCustomParameterValue === 'true'
+            : userCustomParameterValue
+      })
+    }
   })
 
   return parsedValues


### PR DESCRIPTION
Addresses the case when a "user-defined parameter" is not mandatory and left empty. It shouldn't be added to the API URL with an empty value (like "http://api.net/query?param=") as this that might make the API call fail. At least that is our experience with different APIs we have tested. It would be safer to avoid adding anything for that parameter to the query string.

## Proposed Changes

  - When processing the consumer parameters, just consider those that are defined and not empty strings.
