### PR TITLE
Onboarding Proalpha GmbH + Adding AllUnity Token

### DIFF
--- a/pontusxAddresses.json
+++ b/pontusxAddresses.json
@@ -719,5 +719,7 @@
   "0xd0f60a735E28e192fc2bC9d1dbae90D43029420B": "Politecnico di Milano (POLIMI)",
   "0x069c8A8b33C893A6B2b60A20C7EbA7438c5b2D0d": "Josephinum Research (JR)",
   "0xBcEf1784f5A7d12D9281840db626A8faFA247a59": "Turku University of Applied Sciences",
-  "0x752bcd04a2b0ef9b4cafbdebfc98739a6b2d6a52": "Kiel Parking Data"
+  "0x752bcd04a2b0ef9b4cafbdebfc98739a6b2d6a52": "Kiel Parking Data",
+  "0xE158265FD2be5BCc208621f2c0f8AfCF11aC8408": "EURAU",
+  "0x6e9d6595d216477dc57F966415Dd34d9585A0bc3": "Proalpha GmbH"
 }


### PR DESCRIPTION
Adding AllUnity Token - 0xE158265FD2be5BCc208621f2c0f8AfCF11aC8408

Onboarding Proalpha GmbH - 0x6e9d6595d216477dc57F966415Dd34d9585A0bc3

Proalpha GmbH
Auf dem Immel 8
67685 Weilerbach
Germany
Amtsgericht Kaiserslautern HRB 31613
VAT-ID: DE 291170635
LEI Code: 529900R6AJ2UOEIL7218

Public Address: 0x6e9d6595d216477dc57F966415Dd34d9585A0bc3