### PR TITLE
Fix SSR SEO blank output and hydration errors

### DIFF
--- a/src/@context/UserPreferences.tsx
+++ b/src/@context/UserPreferences.tsx
@@ -56,9 +56,10 @@ function UserPreferencesProvider({
   const [debug, setDebug] = useState<boolean>(
     getCookieValue('debug') === 'true'
   )
-  const [currency, setCurrency] = useState<string>(
-    localStorage?.currency || 'EUR'
-  )
+  const [currency, setCurrency] = useState<string>(() => {
+    if (typeof window === 'undefined') return 'EUR'
+    return localStorage?.currency || 'EUR'
+  })
   const [locale, setLocale] = useState<string>()
   const [bookmarks, setBookmarks] = useState(
     getCookieValue('bookmarks')?.split(',') || []

--- a/src/components/@shared/Page/Seo/index.tsx
+++ b/src/components/@shared/Page/Seo/index.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from 'react'
 import Head from 'next/head'
 
-import { isBrowser } from '@utils/index'
 import { useMarketMetadata } from '@context/MarketMetadata'
 import { DatasetSchema } from './DatasetSchema'
 
@@ -19,6 +18,15 @@ export default function Seo({
   // Remove trailing slash from all URLs
   const canonical = `${siteContent?.siteUrl}${uri}`.replace(/\/$/, '')
 
+  // Avoid client/server divergence by not depending on window during render
+  let isProdHostname = false
+  try {
+    const host = new URL(siteContent?.siteUrl || '').hostname
+    isProdHostname = host === 'portal.pontus-x.eu'
+  } catch {
+    isProdHostname = false
+  }
+
   const pageTitle =
     uri === '/'
       ? siteContent?.siteTitle
@@ -30,13 +38,9 @@ export default function Seo({
 
   return (
     <Head>
-      <html lang="en" />
-
       <title>{pageTitle}</title>
 
-      {isBrowser && window?.location?.hostname !== 'portal.pontus-x.eu' && (
-        <meta name="robots" content="noindex,nofollow" />
-      )}
+      {!isProdHostname && <meta name="robots" content="noindex,nofollow" />}
 
       <link rel="canonical" href={canonical} />
       <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -64,9 +68,7 @@ export default function Seo({
       />
 
       <meta property="og:site_name" content={siteContent?.siteTitle} />
-      {isBrowser && window?.location?.hostname === 'portal.pontus-x.eu' && (
-        <meta name="twitter:creator" content="@deltaDAO" />
-      )}
+      {isProdHostname && <meta name="twitter:creator" content="@deltaDAO" />}
       <meta name="twitter:card" content="summary_large_image" />
 
       {datasetSchema && (

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,15 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Restore server-side rendering of the full app subtree (including SEO) by
  creating the URQL client synchronously and always rendering the Provider.
- Eliminate React hydration mismatch by making `<Head>` markup identical on
  server and client, and by moving `<html lang>` to `_document.tsx`.

## Context & Root Cause

- `UrqlProvider` created the GraphQL client inside `useEffect` and gated render
  with `client ? <Provider> : <></>`. During SSR, `useEffect` does not run, so
  the component returned an empty fragment and prevented the entire subtree
  (including SEO) from rendering on the server.
- The SEO component used `window.location.hostname` to conditionally render
  `<meta>` tags. Since `window` is not available during SSR, the `<Head>`
  differed between server and client, causing hydration failures.
- `<html lang="en" />` was rendered inside `<Head>`, which belongs in
  `pages/_document.tsx` and can also contribute to markup divergence.

## Changes

- `src/@context/UrqlProvider.tsx`
  - Initialize URQL client at module load (SSR-safe), remove `useEffect` and
    conditional gating, always render `<Provider>`.
  - On misconfiguration, `getUrqlClientInstance()` throws to surface the issue;
    the Provider component falls back to rendering `{children}` to avoid an
    empty server render.

- `src/components/@shared/Page/Seo/index.tsx`
  - Remove `window` usage; compute robots/twitter meta based on
    `siteContent.siteUrl` so SSR/CSR output is consistent.
  - Remove `<html lang="en" />` from `<Head>`.

- `src/pages/_document.tsx`
  - Add a proper Document and set `<Html lang="en">`.

## Rationale

- SSR requires a stable React tree between server and client. Deferring client
  creation to `useEffect` creates a server-empty/client-nonempty mismatch.
- Head markup must be deterministic on the server. Using `window` during render
  produces divergent `<Head>` content and triggers hydration errors.
- Next.js expects `<Html>` to be managed by `_document.tsx`.

## Impact

- Dynamic SEO is rendered on the server; “View Page Source” now contains full
  `<title>`/`meta`/Open Graph/Twitter tags.
- Hydration errors are resolved; no more
  `Hydration failed because the initial UI does not match`.

## Risks & Mitigations

- URQL client is created at module import time. Since it’s stateless in this
  app (no per-user auth baked into the client), a singleton is acceptable.
- If `subgraphUri` is missing/misconfigured, the getter throws. This is
  intentional to fail fast; the Provider still avoids blank SSR by rendering
  children, but any `useQuery` usage will surface the error immediately.

Fixes #762 